### PR TITLE
Prevent early override of writable directories in Laravel recipe

### DIFF
--- a/recipes/laravel.php
+++ b/recipes/laravel.php
@@ -10,6 +10,10 @@ require_once __DIR__ . '/base.php';
 
 add('recipes', ['laravel']);
 
+set('writable_dirs', [
+  'bootstrap/cache',
+]);
+
 // Override shared directories.
 set('shared_dirs', ['storage']);
 set('shared_files', ['.env']);


### PR DESCRIPTION
- Set 'bootstrap/cache' as a writable directory in the Laravel deployment recipe to correct an issue where earlier configurations were overriding this list, ensuring consistent cache functionality during deployment.