### PR TITLE
AC 8487-218: Add checks for empty database and empty .env on drush config

### DIFF
--- a/recipes/drupal8.php
+++ b/recipes/drupal8.php
@@ -15,23 +15,31 @@ add('rsync_untracked_paths', [
     'public/themes/contrib',
 ]);
 
-desc('Execute database update & config import');
+desc('Execute drush update & config import');
 task('deploy:drush', function () {
-  // https://www.drush.org/latest/deploycommand/
-  invoke('drush:deploy');
+    // https://www.drush.org/latest/deploycommand/
+    invoke('drush:deploy');
 })->once();
 
+desc('Execute drush config:export to backup previous config');
 task('drush:config:backup', function() {
-  if (has('previous_release')) {
-    $destination = '{{previous_release}}/config/backup';
-  }
-  else {
-    $destination = '{{release_path}}/config/backup';
-  }
-  run("mkdir -p $destination");
-  cd ('{{release_or_current_path}}');
-  run("./vendor/bin/drush -y config:export --destination=$destination");
-  writeln('backup saved to ' . $destination);
+    // Skip when there aren't database connection variables.
+    if (! test('[ -s {{release_or_current_path}}/.env ]')) {
+        writeln("<fg=yellow;options=bold;>Warning: </><fg=yellow;>Your .env file is empty! Skipping...</>");
+        return;
+    }
+
+    // Skip when there are no tables in the database.
+    if (test('[[ -z "$(./vendor/bin/drush sql:query \'SHOW TABLES\')" ]]')) {
+        writeln("<fg=yellow;options=bold;>Warning: </><fg=yellow;>Your database is empty! Skipping...</>");
+        return;
+    }
+
+    $destination = has('previous_release') ? '{{previous_release}}' : '{{release_path}}';
+    run("mkdir -p $destination/config/backup");
+    cd('{{release_or_current_path}}');
+    run("./vendor/bin/drush -y config:export --destination=$destination");
+    writeln('Backup saved to ' . $destination);
 });
 before('deploy:drush', 'drush:config:backup');
 


### PR DESCRIPTION
@ramil-ubc I added these checks recently to prevent this from happening when either the .env is missing or the database is empty. Also added a description and some other minor clean-up. Have a peek and see if anything looks awry?